### PR TITLE
fix: add install prefix to debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ --buildsystem=meson
+	dh $@ --buildsystem=meson -- --prefix=/usr


### PR DESCRIPTION
- add install prefix to debian/rules

relates to https://github.com/Vanilla-OS/desktop-image/issues/175